### PR TITLE
update rules to 1.0.1

### DIFF
--- a/rules.md
+++ b/rules.md
@@ -658,7 +658,7 @@ An admin must reply to the user with a valid Confirm Reservation comment as foll
 
 This comment alerts the user that the relevant tasks were reserved and provides the admin’s proof to claim their % of the task(s) reward once they are awarded.
 
-> The admin must also assign the user to the tasks in the relevant Trello checklist, so that the task is no longer shown as unreserved on the Incubator website.
+The admin must also assign the user to the tasks in the relevant Trello checklist, so that the task is no longer shown as unreserved on the Incubator website, and set an appropriate completion date (after discussing this with the user if necessary).
 
 ### 4.3.5 Task Claims
 

--- a/rules.md
+++ b/rules.md
@@ -658,7 +658,7 @@ An admin must reply to the user with a valid Confirm Reservation comment as foll
 
 This comment alerts the user that the relevant tasks were reserved and provides the admin’s proof to claim their % of the task(s) reward once they are awarded.
 
-The admin must also assign the user to the tasks in the Specification Tasks checklist, which will show the task as reserved on the Incubator website.
+> The admin must also assign the user to the tasks in the relevant Trello checklist, so that the task is no longer shown as unreserved on the Incubator website.
 
 ### 4.3.5 Task Claims
 


### PR DESCRIPTION
- update reservations trello action so that it applies to all task types, and also appears as a quote (as for all Trello related instructions)