### PR TITLE
fix: typeerror if some project import fields are null

### DIFF
--- a/_includes/app.js
+++ b/_includes/app.js
@@ -696,6 +696,5 @@ function warningsToTable(data, type) {
 
 
 function nl2br(str) {
-    return str.replace(/(?:\r\n|\r|\n)/g, '<br>');
+    return `${str}`.replace(/(?:\r\n|\r|\n)/g, '<br>');
 }
-


### PR DESCRIPTION
Fix type error on [dashincubator.app](https://dashincubator.app).

There may be a larger problem here that is causing at least one card description or task description to be null.  This gets the site up and running, pending further investigation if desired.

Current:
|Live|Local|
|---|---|
|![image](https://user-images.githubusercontent.com/72463218/162453086-a911c720-b906-409f-a111-211e132ea11f.png)|![image](https://user-images.githubusercontent.com/72463218/162453387-6b2db22d-c41b-4e39-a58b-5e192f5f1a07.png)|

Corrected in this PR, local:
![image](https://user-images.githubusercontent.com/72463218/162614577-0058a8fe-b700-4a58-8e78-4a6bf792649c.png)

### Testing:
No automated testing in place at present, so manual test:

Run the following in a JS environment of your choice.  Expect all `console.logs` to print `::` to the console without errors.
```js
function nl2br(str) {
  return `${str}`.replace(/(?:\r\n|\r|\n)/g, '<br>');
}

console.log(`:${nl2br(null)}:`)
console.log(`:${nl2br(undefined)}:`)
console.log(`:${nl2br('')}:`)
console.log(`:${nl2br()}:`)
```

Replace ```return`${str}`.repl...``` with `return str.repl...` to observe prior behaviour.

### Deployment?
Looks like this may auto-deploy via github pages, but advice on completing the deployment process is very welcome.
